### PR TITLE
container config: add libldap2-dev

### DIFF
--- a/nodepool/runC/debian-buster-rootfs.yaml
+++ b/nodepool/runC/debian-buster-rootfs.yaml
@@ -18,7 +18,7 @@
     {{ bwrap_command }} /bin/bash -lc "apt install -y --allow-unauthenticated gpgv"
     {{ bwrap_command }} /bin/bash -lc "rm -rf /var/lib/apt/lists/* /usr/share/dbus-1/system-services/org.freedesktop.systemd1.service.systemd"
     {{ bwrap_command }} /bin/bash -lc "apt-get update -y"
-    {{ bwrap_command }} /bin/bash -lc "apt-get install -y openssh-server yarnpkg rsync iproute2 git python-pip python3-pip traceroute libpq-dev python2.7 libpython2.7-dev python-pkg-resources python3.7 libpython3.7-dev python3-pkg-resources python-virtualenv python3-virtualenv yamllint flake8 ansible-lint golint"
+    {{ bwrap_command }} /bin/bash -lc "apt-get install -y openssh-server yarnpkg rsync iproute2 git python-pip python3-pip traceroute libpq-dev python2.7 libpython2.7-dev python-pkg-resources python3.7 libpython3.7-dev python3-pkg-resources python-virtualenv python3-virtualenv yamllint flake8 ansible-lint golint libldap2-dev"
     {{ bwrap_command }} /bin/bash -lc "ln -sf /usr/bin/python2.7 /usr/bin/python2"
     {{ bwrap_command }} /bin/bash -lc "pip3 install tox doc8 bashate"
     {{ bwrap_command }} /bin/bash -lc "mkdir -p /run/sshd"

--- a/nodepool/runC/debian-stretch-rootfs.yaml
+++ b/nodepool/runC/debian-stretch-rootfs.yaml
@@ -18,7 +18,7 @@
     {{ bwrap_command }} /bin/bash -lc "apt install -y --allow-unauthenticated gpgv"
     {{ bwrap_command }} /bin/bash -lc "rm -rf /var/lib/apt/lists/* /usr/share/dbus-1/system-services/org.freedesktop.systemd1.service.systemd"
     {{ bwrap_command }} /bin/bash -lc "apt-get update -y"
-    {{ bwrap_command }} /bin/bash -lc "apt-get install -y openssh-server rsync iproute git python-pip python3-pip traceroute libpq-dev python2.7 libpython2.7-dev python-pkg-resources python3.5 libpython3.5-dev python3-pkg-resources"
+    {{ bwrap_command }} /bin/bash -lc "apt-get install -y openssh-server rsync iproute git python-pip python3-pip traceroute libpq-dev python2.7 libpython2.7-dev python-pkg-resources python3.5 libpython3.5-dev python3-pkg-resources libldap2-dev"
     {{ bwrap_command }} /bin/bash -lc "ln -sf /usr/bin/python2.7 /usr/bin/python2"
     {{ bwrap_command }} /bin/bash -lc "pip3 install tox"
     {{ bwrap_command }} /bin/bash -lc "ln -sf /usr/sbin/sshd /sbin/sshd"

--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -72,7 +72,8 @@ resources:
         - wazo-pbx/xivo-dao
         - wazo-pbx/xivo-dbms
         - wazo-pbx/xivo-dev-ssh-pubkeys
-        - wazo-pbx/wazo-dird
+        - wazo-pbx/wazo-dird:
+            zuul/exclude-unprotected-branches: true
         - wazo-pbx/wazo-dird-phoned
         - wazo-pbx/xivo-dist
         - wazo-pbx/xivo-dxtora


### PR DESCRIPTION
libldap2-dev is required to be able to install the python-ldap package which is
a requirement of wazo-dird