### PR TITLE
add pipeline for auto-merging PR

### DIFF
--- a/zuul.d/local_pipelines.yaml
+++ b/zuul.d/local_pipelines.yaml
@@ -1,0 +1,57 @@
+
+- pipeline:
+    name: auto-merge
+    description: |
+      Changes that have been self-approved (auto-merge label) are enqueued
+      in order in this pipeline, and if they pass tests, will be
+      merged.
+    success-message: Build succeeded (auto-merge pipeline).
+    failure-message: |
+      Build failed (auto-merge pipeline).  For information on how to proceed, see
+      http://docs.openstack.org/infra/manual/developers.html#automated-testing
+    manager: dependent
+    precedence: high
+    post-review: True
+    require:
+      github.com:
+        # Require label
+        label: auto-merge
+        status: "wazo-zuul\\[bot\\]:local/check:success"
+        open: True
+        current-patchset: True
+    trigger:
+      github.com:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*remerge\s*$
+        - event: pull_request_review
+          action: submitted
+          state: approved
+        - event: pull_request_review
+          action: dismissed
+          state: request_changes
+        - event: pull_request
+          action: status
+          status: "wazo-zuul\\[bot\\]:local/check:success"
+        - event: pull_request
+          action: labeled
+          label:
+            - auto-merge
+    start:
+      github.com:
+        status: 'pending'
+        status-url: "https://zuul.wazo.community/zuul/t/local/status.html"
+        comment: false
+    success:
+      github.com:
+        status: 'success'
+        merge: true
+        comment: true
+      sqlreporter:
+    failure:
+      github.com:
+        status: 'failure'
+        comment: true
+      sqlreporter:
+    window-floor: 20
+    window-increase-factor: 2


### PR DESCRIPTION
Why:

* Sometimes small PR do not need approval by someone else, and Github
does not allow self-approving a PR.

How:

* Create a auto-merge pipeline that would automatically approve the PR
if the PR is labeled "auto-merge"